### PR TITLE
issue#2: Fix color value begin with '#'

### DIFF
--- a/i3bang.rb
+++ b/i3bang.rb
@@ -7,7 +7,7 @@ def i3bang config, header = ''
     # kill comments; bangs in them interfere
     # also annoying trailing whitespace
     nobracket = config.include? '#!nobracket'
-    config.gsub! /\s*#.*\n/, "\n"
+    config.gsub! /\s*#[! ].*\n/, "\n"
     config.gsub! /\s+$/, ''
 
     # line continuations

--- a/i3bang.rb
+++ b/i3bang.rb
@@ -269,3 +269,4 @@ if __FILE__ == $0
             -b 'show errors' 'i3-sensible-pager /tmp/i3bangerr.txt'`
     end
 end
+# vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4:

--- a/i3bang.rb
+++ b/i3bang.rb
@@ -7,7 +7,7 @@ def i3bang config, header = ''
     # kill comments; bangs in them interfere
     # also annoying trailing whitespace
     nobracket = config.include? '#!nobracket'
-    config.gsub! /\s*#[! ].*\n/, "\n"
+    config.gsub! /\s*#*#[! ].*\n/, "\n"
     config.gsub! /\s+$/, ''
 
     # line continuations

--- a/test.rb
+++ b/test.rb
@@ -132,3 +132,4 @@ class TestI3bang < Test::Unit::TestCase
         assert_i3bang '_!1+1 + 2     ', '_2 + 2'
     end
 end
+# vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4:


### PR DESCRIPTION
Fix color value begin with '#'. But let the valid comments must begin with '# '(a space is needed).
Also added vim modeline to match the format of your original files while editing in VIM.
