### PR TITLE
Add file including mechanism

### DIFF
--- a/i3bang.rb
+++ b/i3bang.rb
@@ -85,6 +85,16 @@ def i3bang config, header = ''
     end
     expand_nobracket config if nobracket
 
+    # include file content
+    config.gsub!(/!#<([^>]*)>/) {
+        incfile = File.expand_path($1)
+        begin
+            data = File.read(incfile)
+        rescue
+            raise I3bangError, "Cannot read from file: #{incfile}"
+        end
+    }
+
     # first check for !?<...> environment variable conditionals
     config.gsub!(/!\?<([\s\S]*?\n)>(?=\n)/) {
         condition, data = $1.split "\n", 2


### PR DESCRIPTION
I've added a mechanism to including external files into `_config`. By using `<!#PATH_TO_FILE>` syntax, it can include the content of the external file.

I'm using it to switch i3 color themes. I made a symlink to a color theme file, which only contains i3wm's color settings, and included this symlink in `_config`. So, next time I change theme, I need only change the symlink to another theme file, and reload i3wm.

BTW, thanks for your great work.
